### PR TITLE
Report active status when the charm is ready

### DIFF
--- a/reactive/kubeflow_seldon_api_frontend.py
+++ b/reactive/kubeflow_seldon_api_frontend.py
@@ -7,6 +7,11 @@ from charms.reactive import when, when_not
 from charms import layer
 
 
+@when('charm.kubeflow-seldon-api-frontend.started')
+def charm_ready():
+    layer.status.active('')
+
+
 @when('layer.docker-resource.api-frontend-image.changed')
 def update_image():
     clear_flag('charm.kubeflow-seldon-api-frontend.started')


### PR DESCRIPTION
When charm has pushed the pod spec, report status as active so juju can correctly reflect the unit status when the container has started.